### PR TITLE
Fix for TypeError if file duration is unknown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -164,7 +164,7 @@ Ffmpeg.prototype.processInitialOutput = function(text) {
 };
 
 Ffmpeg.prototype.processProgress = function(text) {
-    var duration = this.options.duration || this._details.file.duration;
+    var duration = this.options.duration || (this._details.file && this._details.file.duration) || null;
     var data = text
         .trim()
         .replace(/=\ */g, '=')
@@ -178,11 +178,15 @@ Ffmpeg.prototype.processProgress = function(text) {
     data.time = helper.humanTimeToMS(data.time);
     data.speed = parseFloat(data.speed.replace('x', ''));
 
-    // compute progress
-    data.progress = data.time / duration;
+    if(duration !== null) {
+        // compute progress
+        data.progress = data.time / duration;
 
-    // compute ETA
-    data.eta = ((duration - data.time) / data.speed) | 0;
+        // compute ETA
+        data.eta = ((duration - data.time) / data.speed) | 0;
+    } else {
+        data.progress = data.eta = null;
+    }
 
     this.emit('progress', data);
 };


### PR DESCRIPTION
```
C:\Users\aaa4xu\PhpstormProjects\ffmpeg\node_modules\ffmpeg-progress-wrapper\lib\index.js:167
    var duration = this.options.duration || this._details.file.duration;
                                                               ^
TypeError: Cannot read property 'duration' of undefined
    at Ffmpeg.processProgress (C:\Users\aaa4xu\PhpstormProjects\ffmpeg\node_modules\ffmpeg-progress-wrapper\lib\index.js:167:64)
    at Ffmpeg.processOutput (C:\Users\aaa4xu\PhpstormProjects\ffmpeg\node_modules\ffmpeg-progress-wrapper\lib\index.js:145:14)
    at Socket.emit (events.js:182:13)
    at Socket.EventEmitter.emit (domain.js:441:20)
    at addChunk (_stream_readable.js:283:12)
    at readableAddChunk (_stream_readable.js:264:11)
    at Socket.Readable.push (_stream_readable.js:219:10)
    at Pipe.onStreamRead [as onread] (internal/stream_base_commons.js:122:17)
```